### PR TITLE
feat: deprecate requirements.txt file in favor of using pyproject dependencies argument

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,8 @@ repos:
       - id: mypy
         args: [--ignore-missing-imports, --check-untyped-defs]
         additional_dependencies: [types-PyYAML]
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.24.2
     hooks:
-      - id: requirements-txt-fixer
+      - id: toml-sort
+        args: ["--all", "--trailing-comma-inline-array"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "python_project"
 version = "0.0.1"
-dynamic = ["dependencies"]
 requires-python = ">=3.8"
+dependencies = [
+  "pre-commit",
+  "pytest",
+  "pytest-cov",
+]
 
 [tool.coverage]
 branch = true
@@ -48,6 +52,3 @@ no-lines-before = ["local-folder"]
 
 [tool.setuptools]
 packages = ["src"]
-
-[tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-pre-commit
-pytest
-pytest-cov


### PR DESCRIPTION
this pr depreactes `requirements.txt` in favour of using pyproject `dependencies` argument